### PR TITLE
make the mod work again on servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ src/main/resources/mixins.*.json
 *.bat
 *.DS_Store
 !gradlew.bat
+layout.json

--- a/gradle.properties
+++ b/gradle.properties
@@ -87,7 +87,7 @@ apiPackage =
 accessTransformersFile =
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
-usesMixins = false
+usesMixins = true
 
 # Set to a non-empty string to configure mixins in a separate source set under src/VALUE, instead of src/main.
 # This can speed up compile times thanks to not running the mixin annotation processor on all input sources.
@@ -95,7 +95,7 @@ usesMixins = false
 separateMixinSourceSet =
 
 # Adds some debug arguments like verbose output and class export.
-usesMixinDebug = false
+usesMixinDebug = true
 
 # Specify the location of your implementation of IMixinConfigPlugin. Leave it empty otherwise.
 mixinPlugin =
@@ -103,12 +103,12 @@ mixinPlugin =
 # Specify the package that contains all of your Mixins. The package must exist or
 # the build will fail. If you have a package property defined in your mixins.<modid>.json,
 # it must match with this or the build will fail.
-mixinsPackage =
+mixinsPackage = mixins
 
 # Specify the core mod entry class if you use a core mod. This class must implement IFMLLoadingPlugin!
 # This parameter is for legacy compatibility only
 # Example value: (coreModClass = asm.FMLPlugin) + (modGroup = com.myname.mymodid) -> com.myname.mymodid.asm.FMLPlugin
-coreModClass =
+coreModClass = mixins.MixinLoadingPlugin
 
 # If your project is only a consolidation of mixins or a core mod and does NOT contain a 'normal' mod ( = some class
 # that is annotated with @Mod) you want this to be true. When in doubt: leave it on false!

--- a/src/main/java/net/torocraft/torohealthmod/client/event/ToroHealthEventHandler.java
+++ b/src/main/java/net/torocraft/torohealthmod/client/event/ToroHealthEventHandler.java
@@ -1,8 +1,10 @@
 package net.torocraft.torohealthmod.client.event;
 
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.MathHelper;
-import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.event.entity.living.LivingEvent;
 import net.torocraft.torohealthmod.client.particle.DamageParticles;
+import net.torocraft.torohealthmod.mixins.interfaces.EntityLivingBaseExt;
 
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -10,8 +12,21 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 public class ToroHealthEventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOW)
-    public void onLivingHurt(LivingHurtEvent event) {
-        DamageParticles.spawnDamageParticle(event.entityLiving, MathHelper.floor_float(event.ammount));
+    public void onLivingUpdate(LivingEvent.LivingUpdateEvent event) {
+        final EntityLivingBase entity = event.entityLiving;
+        if (!entity.worldObj.isRemote) return;
+
+        final int prevHealth = ((EntityLivingBaseExt) entity).torohealth$getPrevHealth();
+        final int health = MathHelper.floor_float(entity.getHealth());
+
+        if (prevHealth != health) {
+            ((EntityLivingBaseExt) entity).torohealth$setPrevHealth(health);
+
+            // -1 means that prevHealth wasn't initialized because the Living has just spawned
+            if (prevHealth != -1) {
+                DamageParticles.spawnDamageParticle(entity, prevHealth - health);
+            }
+        }
     }
 
 }

--- a/src/main/java/net/torocraft/torohealthmod/mixins/MixinLoadingPlugin.java
+++ b/src/main/java/net/torocraft/torohealthmod/mixins/MixinLoadingPlugin.java
@@ -1,0 +1,53 @@
+package net.torocraft.torohealthmod.mixins;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader;
+
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
+import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
+
+@IFMLLoadingPlugin.MCVersion("1.7.10")
+public class MixinLoadingPlugin implements IEarlyMixinLoader, IFMLLoadingPlugin {
+
+    @Override
+    public String[] getASMTransformerClass() {
+        return null;
+    }
+
+    @Override
+    public String getModContainerClass() {
+        return null;
+    }
+
+    @Override
+    public String getSetupClass() {
+        return null;
+    }
+
+    @Override
+    public void injectData(Map<String, Object> data) {}
+
+    @Override
+    public String getAccessTransformerClass() {
+        return null;
+    }
+
+    @Override
+    public String getMixinConfig() {
+        return "mixins.torohealthmod.early.json";
+    }
+
+    @Override
+    public List<String> getMixins(Set<String> loadedCoreMods) {
+        final ArrayList<String> list = new ArrayList<>();
+        if (FMLLaunchHandler.side().isClient()) {
+            list.add("MixinEntityLivingBase");
+        }
+        return list;
+    }
+
+}

--- a/src/main/java/net/torocraft/torohealthmod/mixins/early/MixinEntityLivingBase.java
+++ b/src/main/java/net/torocraft/torohealthmod/mixins/early/MixinEntityLivingBase.java
@@ -1,0 +1,25 @@
+package net.torocraft.torohealthmod.mixins.early;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.torocraft.torohealthmod.mixins.interfaces.EntityLivingBaseExt;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(EntityLivingBase.class)
+public abstract class MixinEntityLivingBase implements EntityLivingBaseExt {
+
+    @Unique
+    private int torohealth$prevHealth = -1;
+
+    @Unique
+    public int torohealth$getPrevHealth() {
+        return torohealth$prevHealth;
+    }
+
+    @Unique
+    public void torohealth$setPrevHealth(int prevHealth) {
+        this.torohealth$prevHealth = prevHealth;
+    }
+
+}

--- a/src/main/java/net/torocraft/torohealthmod/mixins/interfaces/EntityLivingBaseExt.java
+++ b/src/main/java/net/torocraft/torohealthmod/mixins/interfaces/EntityLivingBaseExt.java
@@ -1,0 +1,8 @@
+package net.torocraft.torohealthmod.mixins.interfaces;
+
+public interface EntityLivingBaseExt {
+
+    int torohealth$getPrevHealth();
+
+    void torohealth$setPrevHealth(int torohealth$prevHealth);
+}

--- a/src/main/resources/mixins.torohealthmod.early.json
+++ b/src/main/resources/mixins.torohealthmod.early.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "minVersion": "0.8.5-GTNH",
+  "package": "net.torocraft.torohealthmod.mixins.early",
+  "refmap": "mixins.torohealthmod.refmap.json",
+  "target": "@env(DEFAULT)",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "client": [],
+  "server": []
+}

--- a/src/main/resources/mixins.torohealthmod.json
+++ b/src/main/resources/mixins.torohealthmod.json
@@ -1,0 +1,10 @@
+{
+  "required": true,
+  "minVersion": "0.8.5-GTNH",
+  "refmap": "mixins.torohealthmod.refmap.json",
+  "target": "@env(DEFAULT)",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "client": [],
+  "server": []
+}


### PR DESCRIPTION
This PR fixes problems introduced in #5 mainly by reverting the last commit from there

LivingHurtEvent has two serious flaws:
1) it’s server side only, so it works fine in singleplayer but requires client-server packet communication to work on servers
2) it works only when damaging entities, but this mod should show changes in hp on both hurt and heal actions

about the prevHp field that minecraft provides: it stores the actual prevHp only when changing hp after being hurt, so we can’t reuse it because we also need to consider heal
