### PR TITLE
Hide health popup on entity spawn

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 // Add your dependencies here
 
 dependencies {
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:waila:1.9.15:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:waila:1.19.30:dev")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,13 +39,33 @@ remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/co
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
 developmentEnvironmentUserName = Developer
 
-# Enables using modern Java syntax (up to version 17) via Jabel, while still targeting JVM 8.
-# See https://github.com/bsideup/jabel for details on how this works.
-enableModernJavaSyntax = true
+# Enables modern Java syntax support. Valid values:
+# - false: No modern syntax, Java 8 only
+# - jabel: Jabel syntax-only support, compiles to J8 bytecode
+# - jvmDowngrader: Full modern Java via JVM Downgrader (syntax + stdlib APIs)
+# - modern: Native modern Java bytecode, no downgrading
+enableModernJavaSyntax = jabel
 
 # If set, ignores the above setting and compiles with the given toolchain. This may cause unexpected issues,
 # and should *not* be used in most situations. -1 disables this.
 # forceToolchainVersion = -1
+
+# Target JVM version for JVM Downgrader bytecode downgrading.
+# Only used when enableModernJavaSyntax = jvmDowngrader
+# downgradeTargetVersion = 8
+
+# Comma-separated list of Java versions for multi-release jar support (JVM Downgrader only).
+# Classes will be available in META-INF/versions/N/ for each version N in this list.
+# Default: "21,25" (J25+ gets native classes, J21-24 gets partial downgrade, J8-20 gets full downgrade).
+# jvmDowngraderMultiReleaseVersions = 21,25
+
+# Specifies how JVM Downgrader API stubs are provided. Options:
+# - shade: Shade minimized stubs into the jar
+# - gtnhlib: GTNHLib provides stubs at runtime (adds version constraint)
+# - external: Another dependency provides stubs (no constraint, no warning)
+# - (empty): Warning reminding you to configure stubs
+# Note: 'shade' option requires you to verify license compliance, see: https://github.com/unimined/JvmDowngrader/blob/main/LICENSE.md
+# jvmDowngraderStubsProvider =
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '2.0.7'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '2.0.26'
 }
 
 

--- a/src/main/java/net/torocraft/torohealthmod/client/event/ToroHealthEventHandler.java
+++ b/src/main/java/net/torocraft/torohealthmod/client/event/ToroHealthEventHandler.java
@@ -16,14 +16,23 @@ public class ToroHealthEventHandler {
         final EntityLivingBase entity = event.entityLiving;
         if (!entity.worldObj.isRemote) return;
 
+        final int prevMaxHealth = ((EntityLivingBaseExt) entity).torohealth$getPrevMaxHealth();
+        final int maxHealth = MathHelper.floor_float(entity.getMaxHealth());
+
+        if (prevMaxHealth != maxHealth) {
+            ((EntityLivingBaseExt) entity).torohealth$setPrevMaxHealth(maxHealth);
+        }
+
         final int prevHealth = ((EntityLivingBaseExt) entity).torohealth$getPrevHealth();
         final int health = MathHelper.floor_float(entity.getHealth());
 
         if (prevHealth != health) {
             ((EntityLivingBaseExt) entity).torohealth$setPrevHealth(health);
 
-            // -1 means that prevHealth wasn't initialized because the Living has just spawned
-            if (prevHealth != -1) {
+            // -1 means that prevHealth wasn't initialized because the Living has just spawned.
+            // Ignore cases where max health was changed (as this most likely signals an external mod modifying health
+            // during entity spawn, like EnderZoo's health modifier).
+            if (prevHealth != -1 && prevMaxHealth == maxHealth) {
                 DamageParticles.spawnDamageParticle(entity, prevHealth - health);
             }
         }

--- a/src/main/java/net/torocraft/torohealthmod/mixins/early/MixinEntityLivingBase.java
+++ b/src/main/java/net/torocraft/torohealthmod/mixins/early/MixinEntityLivingBase.java
@@ -13,13 +13,26 @@ public abstract class MixinEntityLivingBase implements EntityLivingBaseExt {
     private int torohealth$prevHealth = -1;
 
     @Unique
+    private int torohealth$prevMaxHealth = -1;
+
+    @Override
     public int torohealth$getPrevHealth() {
         return torohealth$prevHealth;
     }
 
-    @Unique
+    @Override
+    public int torohealth$getPrevMaxHealth() {
+        return torohealth$prevMaxHealth;
+    }
+
+    @Override
     public void torohealth$setPrevHealth(int prevHealth) {
         this.torohealth$prevHealth = prevHealth;
+    }
+
+    @Override
+    public void torohealth$setPrevMaxHealth(int prevMaxHealth) {
+        this.torohealth$prevMaxHealth = prevMaxHealth;
     }
 
 }

--- a/src/main/java/net/torocraft/torohealthmod/mixins/interfaces/EntityLivingBaseExt.java
+++ b/src/main/java/net/torocraft/torohealthmod/mixins/interfaces/EntityLivingBaseExt.java
@@ -4,5 +4,9 @@ public interface EntityLivingBaseExt {
 
     int torohealth$getPrevHealth();
 
+    int torohealth$getPrevMaxHealth();
+
     void torohealth$setPrevHealth(int torohealth$prevHealth);
+
+    void torohealth$setPrevMaxHealth(int torohealth$prevMaxHealth);
 }


### PR DESCRIPTION
In GTNH, there is this odd glitch where the ToroHealth health popup/particle appears directly on mob spawn (which it's not supposed to do). This seems to be caused by EnderZoo which globally modifies mob health in the server tick handler a bit after spawn.

This attempts to fix this by filtering changes to max health.

Before:

https://github.com/user-attachments/assets/6b0ef2a7-a12b-48d6-b480-767e85441898

After:

https://github.com/user-attachments/assets/8b77477a-231a-488c-8546-3db95d9b9606

